### PR TITLE
Updated alert manager to use placeholder credentials

### DIFF
--- a/team8-app/templates/alertmanager-cfg.yaml
+++ b/team8-app/templates/alertmanager-cfg.yaml
@@ -3,18 +3,18 @@ kind: AlertmanagerConfig
 metadata:
   name: email-config
   labels: 
-    release: myprom 
+    alertmanagerConfig: alertmanagercfg
 spec:
   route:
     receiver: 'email-alerts'
   receivers:
-  - name: 'email-alerts'
-    emailConfigs:
-    - to: "team8doda@gmail.com"
-      from: "team8doda@gmail.com"
-      smarthost: "smtp.gmail.com:587"
-      authUsername: "team8doda@gmail.com"
-      authPassword:
-        name: alertmanager-smtp-secret
-        key: SMTP_PASSWORD
-      requireTLS: true
+    - name: 'email-alerts'
+      emailConfigs:
+      - to: {{ .Values.alertmanager.email.to}}
+        from: {{ .Values.alertmanager.email.from }}
+        smarthost: {{ .Values.alertmanager.email.smarthost }}
+        authUsername: {{ .Values.alertmanager.email.authUsername }}
+        authPassword:
+          name: alertmanager-smtp-secret
+          key: SMTP_PASSWORD
+        requireTLS: true

--- a/team8-app/templates/alertmanager-secret.yaml
+++ b/team8-app/templates/alertmanager-secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-smtp-secret
+data:
+  SMTP_PASSWORD: {{ .Values.alertmanager.email.authPassword }} # should be base64 encoded

--- a/team8-app/templates/alertmanager.yaml
+++ b/team8-app/templates/alertmanager.yaml
@@ -2,10 +2,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
   name: email-alert
-  labels: 
+  labels:
     release: myprom
 spec:
   replicas: 1
   alertmanagerConfigSelector:
     matchLabels:
-      release: myprom
+      alertmanagerConfig: alertmanagercfg

--- a/team8-app/templates/environment.yaml
+++ b/team8-app/templates/environment.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: alertmanager-smtp-secret
-data:
-  SMTP_PASSWORD: cmlkZiBta2VuIGZlcHAgZmVscg==

--- a/team8-app/templates/prometheusrule.yaml
+++ b/team8-app/templates/prometheusrule.yaml
@@ -2,11 +2,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: sms-app-alert
-  labels: 
-    release: myprom 
+  labels:
+    release: myprom
 spec:
   groups:
-    - name: sms-app-rules
+    - name: sms-app-rules 
       rules:
         - alert: HighRequestRate
           expr: rate(app_sms_requests_total[1m]) > 15

--- a/team8-app/values.yaml
+++ b/team8-app/values.yaml
@@ -46,6 +46,16 @@ model_shadow:
     app: model-service 
     component: ml-model
 
+alertmanager:
+  email:
+    to: "recieveremail@example.com" # here replace with the receiver's email adress
+    from: "email@example.com" # here replace with the sender's email
+    smarthost: "smtp.gmail.com:587" # SMTP server address and port (for our testing we used gmail)
+    authUsername: "email@example.com" # SMTP username (usually your email password)
+    authPassword: "password" # SMTP password (your email password base64 encoded)
+                             # you may need to generate an app password depending on your provider
+    requireTLS: true
+
 grafana:
     namespace: default
 


### PR DESCRIPTION
Updated alertmanager  to not contain credentials.
Replace the fields in values with your email and password for testing or replace at installation.